### PR TITLE
Webpack and player height rendering patch

### DIFF
--- a/src/controllers/player.coffee
+++ b/src/controllers/player.coffee
@@ -20,6 +20,8 @@ Enigma.controller 'enigmaPlayerCtrl', ['$scope', '$timeout', ($scope, $timeout) 
 	$scope.percentCorrect = 0
 	$scope.percentIncorrect = 0
 
+	$scope.delayedHeaderInit = false
+
 	# Called by Materia.Engine when your widget Engine should start the user experience.
 	$scope.start = (instance, qset, version = '1') ->
 		$scope.title = instance.name
@@ -32,8 +34,11 @@ Enigma.controller 'enigmaPlayerCtrl', ['$scope', '$timeout', ($scope, $timeout) 
 				$scope.totalQuestions++
 
 		$scope.$apply()
-
 		Materia.Engine.setHeight()
+
+		# delay header draw until after gameboard is rendered, forcing recalculation of visible area. This appears to be a chrome 76 bug related to changing iframe height
+		$timeout ->
+			$scope.delayedHeaderInit = true
 
 	# randomize the order of a question's answers
 	_shuffle = (a) ->

--- a/src/player.html
+++ b/src/player.html
@@ -18,7 +18,7 @@
 		<script src="player.js"></script>
 	</head>
 	<body ng-app='enigmaPlayer' ng-controller='enigmaPlayerCtrl'>
-		<header>
+		<header ng-show="delayedHeaderInit">
 			<h1>{{ title }}</h1>
 			<div id='scorebox' class='score' role='status'>
 				<!-- Sigh. We're using Raphael to generate this. Try and find a way of doing it that doesn't require some other library. -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,10 +15,10 @@ const customCopy = copy.concat([
 
 const entries = {
 	'creator.js': [
-		path.join(__dirname, 'src', 'directives/enter.coffee'),
-		path.join(__dirname, 'src', 'directives/focus.coffee'),
 		path.join(__dirname, 'src', 'modules/creator.coffee'),
-		path.join(__dirname, 'src', 'controllers/creator.coffee')
+		path.join(__dirname, 'src', 'controllers/creator.coffee'),		
+		path.join(__dirname, 'src', 'directives/enter.coffee'),
+		path.join(__dirname, 'src', 'directives/focus.coffee')
 	],
 	'player.js': [
 		path.join(__dirname, 'src', 'modules/player.coffee'),


### PR DESCRIPTION
Fixes webpack compiling error with the creator, due to ordering flaw in `creator.js` entries

Also adds a delay to the rendering of the player header, forcing a recalculation of the visible height _after_ the `Materia.Engine.setHeight()` call is made. This resolves a problem in Chrome where category questions below the initial visible area were not selectable.